### PR TITLE
Increase the datetime range precision to milliseconds in Solr query

### DIFF
--- a/oai2-plugin/src/main/java/org/socialhistoryservices/api/oai/Parsing.java
+++ b/oai2-plugin/src/main/java/org/socialhistoryservices/api/oai/Parsing.java
@@ -128,8 +128,8 @@ public class Parsing {
      * parseRange
      * <p/>
      * The range will determine to pad to the present or future:
-     * range(from)  => 2001-02-03 => 2001-02-03T00:00:00Z
-     * range(until) => 2001-02-03 => 2001-02-03T23:59:59Z
+     * range(from)  => 2001-02-03 => 2001-02-03T00:00:00.000Z
+     * range(until) => 2001-02-03 => 2001-02-03T23:59:59.999Z
      * <p/>
      *
      * @return An ISO 8601 formatted date or an infinite range Lucene character when the date is null
@@ -138,8 +138,12 @@ public class Parsing {
 
         if (datestamp == null) return "*";
 
-        return (datestamp.length() == GranularityType.YYYY_MM_DD_THH_MM_SS_Z.value().length()) ? datestamp
-                : (range.equalsIgnoreCase("from")) ? datestamp.concat("T00:00:00Z") : datestamp.concat("T23:59:59Z");
+        boolean from = range.equalsIgnoreCase("from");
+        if (datestamp.length() == GranularityType.YYYY_MM_DD_THH_MM_SS_Z.value().length()) {
+            return datestamp.replace("Z", from ? ".000Z" : ".999Z");
+        } else {
+            return datestamp.concat(from ? "T00:00:00.000Z" : "T23:59:59.999Z");
+        }
     }
 
 

--- a/oai2-plugin/src/test/java/org/socialhistoryservices/api/oai/TestValidation.java
+++ b/oai2-plugin/src/test/java/org/socialhistoryservices/api/oai/TestValidation.java
@@ -157,12 +157,12 @@ public class TestValidation extends TestCase {
         assertEquals("*", Parsing.parseRange(null, "from"));
 
         identify.setGranularity(GranularityType.YYYY_MM_DD);
-        assertEquals("2012-02-03T00:00:00Z", Parsing.parseRange("2012-02-03", "from"));
-        assertEquals("2012-02-03T23:59:59Z", Parsing.parseRange("2012-02-03", "until"));
+        assertEquals("2012-02-03T00:00:00.000Z", Parsing.parseRange("2012-02-03", "from"));
+        assertEquals("2012-02-03T23:59:59.999Z", Parsing.parseRange("2012-02-03", "until"));
 
         identify.setGranularity(GranularityType.YYYY_MM_DD_THH_MM_SS_Z);
-        assertEquals("2012-02-03T04:05:06Z", Parsing.parseRange("2012-02-03T04:05:06Z", "from"));
-        assertEquals("2012-02-03T04:05:06Z", Parsing.parseRange("2012-02-03T04:05:06Z", "until"));
+        assertEquals("2012-02-03T04:05:06.000Z", Parsing.parseRange("2012-02-03T04:05:06Z", "from"));
+        assertEquals("2012-02-03T04:05:06.999Z", Parsing.parseRange("2012-02-03T04:05:06Z", "until"));
     }
 
     public void testIsValidDatestampRange() {


### PR DESCRIPTION
OAI validator shows that if the Solr datetime field is indexed with milliseconds precision, the OAI plugin can't include documents that have been indexed in a one second range. 

For example, a document has been indexed at **2020-11-18T13:48:23.160Z** and someone requests for it with the seconds precision (max. precision according to the documentation). Then the plugin constructs the query like field:[**2020-11-18T13:48:23Z** TO **2020-11-18T13:48:23Z**], but Solr understands it as a range from **2020-11-18T13:48:23.000Z** to **2020-11-18T13:48:23.000Z**, so the document is not included in the search result. 

Just for building the query, I added an increase in precision to milliseconds, think that can be useful for such situations, can it be?